### PR TITLE
Proper check to see if the ECDSA key has a compressed public key

### DIFF
--- a/keylib/private_key.py
+++ b/keylib/private_key.py
@@ -35,8 +35,8 @@ class ECPrivateKey():
             secret_exponent = random_secret_exponent(self._curve.order)
         else:
             secret_exponent = encode_privkey(private_key, 'decimal')
-            if get_privkey_format(private_key).endswith('compressed'):
-                self._compressed = True
+            if not get_privkey_format(private_key).endswith('compressed'):
+                self._compressed = False
 
         # make sure that: 1 <= secret_exponent < curve_order
         if not is_secret_exponent(secret_exponent, self._curve.order):


### PR DESCRIPTION
Since the constructor now assumes that the private key may embed a compressed public key (departing from the otherwise-equivalent code in pybitcoin), we need to detect if the formatted private key contains an _uncompressed_ public key, and set the `_compressed` member accordingly.
